### PR TITLE
build(deps): bump golang.org/x/sync from 0.6.0 to 0.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/neilotoole/fifomu
 
 go 1.26
 
-require golang.org/x/sync v0.6.0
+require golang.org/x/sync v0.20.0
 
 require go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Bumps the test-only `golang.org/x/sync` dependency from 0.6.0 straight to the current 0.20.0, superseding the stale Dependabot #1 (which targeted the long-obsolete 0.7.0 and had gone into merge conflict against master after the goleak test dep was added).

`x/sync` is used only by the benchmark baseline (`semaphore.Weighted`); `fifomu.Mutex` itself depends only on the standard library, so there is no runtime impact.

Verified locally: `go build ./...`, `go test -race ./...`, and `golangci-lint run` all pass; the semaphore-baseline benchmarks still compile and run.